### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: tanzu-java-web-app-lab06
+  annotations:
+    github.com/project-slug: fiona8953/tanzu-java-web-app-lab06
+spec:
+  type: other
+  lifecycle: unknown
+  owner: default-team


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [VMware Tanzu Application Platform software catalog](https://tap-gui.build.tap-06.slot-35.tanzu-gss-labs.vmware.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).